### PR TITLE
fix(backend):すぐメイン画面に遷移されるバグを修正

### DIFF
--- a/frontend/hooks/AuthProvider.tsx
+++ b/frontend/hooks/AuthProvider.tsx
@@ -75,12 +75,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         } catch (e) {
           console.error('ユーザー情報の取得に失敗しました:', e);
           setUser(null);
-          if (pathname !== '/login' && pathname !== '/signup') {
+          if (pathname !== '/login' && pathname !== '/signup' && 
+              pathname !== '/password-reset-request' && pathname !== '/password-reset-confirm') {
             router.replace('/login');
           }
         }
       } else {
-        if (pathname !== '/login' && pathname !== '/signup') {
+        if (pathname !== '/login' && pathname !== '/signup' && 
+            pathname !== '/password-reset-request' && pathname !== '/password-reset-confirm') {
           router.replace('/login');
         }
       }


### PR DESCRIPTION
## 修正内容

パスワードリセット画面が認証チェックによりメイン画面に自動遷移される問題を修正しました。

### 問題
- パスワードリセット画面（`/password-reset-request`、`/password-reset-confirm`）にアクセスすると、認証されていない状態でメイン画面にリダイレクトされる
- パスワードリセット機能が正常に動作しない

### 解決方法
`AuthProvider.tsx`でパスワードリセット関連の画面を認証チェックから除外：

